### PR TITLE
Set isBlocking true if the input type uses a handler that blocks.

### DIFF
--- a/src/main/java/io/sinistral/proteus/server/ServerResponse.java
+++ b/src/main/java/io/sinistral/proteus/server/ServerResponse.java
@@ -253,6 +253,12 @@ public class ServerResponse<T>
 		return this;
 	}
 
+        public ServerResponse<T> status(Response.Status status)
+	{
+		this.status = status.getStatusCode();
+                return this;
+        }
+        
 	public ServerResponse<T> status(int status)
 	{
 		this.status = status;

--- a/src/main/java/io/sinistral/proteus/server/handlers/HandlerGenerator.java
+++ b/src/main/java/io/sinistral/proteus/server/handlers/HandlerGenerator.java
@@ -466,6 +466,12 @@ public class HandlerGenerator
 
 			endpointInfo.setConsumes(consumesContentType);
 
+            //The handler for these two inputs types is blocking, so we set the flag
+            if (endpointInfo.getConsumes().equals("application/x-www-form-urlencoded")
+                    || endpointInfo.getConsumes().equals("multipart/form-data")) {
+                isBlocking = true;
+            }
+
 			endpointInfo.setPathTemplate(methodPath);
 
 			endpointInfo.setControllerMethod(m.getName());


### PR DESCRIPTION
I'm sure there's a better way to do this, but I'm not sure what it is. I'm building something with Proteus that accepts Posts and returns json. As best I can tell, Proteus determines whether a method is blocking or not based solely on the output type. Since I'm not using one of the output types that is blocking, it assumes my method isn't blocking.

Of course, the input handler for multipart IS blocking, resulting in undertow throwing an exception. I looked for where input handlers are configured during generation, but I couldn't find anything. 

So, I resorted to this hack. 

Thanks for Proteus, it's exactly what I was looking for!