### PR TITLE
Incorrect File.seperator use - broken on Windows.

### DIFF
--- a/proteus-openapi/src/main/java/io/sinistral/proteus/openapi/services/OpenAPIService.java
+++ b/proteus-openapi/src/main/java/io/sinistral/proteus/openapi/services/OpenAPIService.java
@@ -319,7 +319,7 @@ public class OpenAPIService extends DefaultService implements Supplier<RoutingHa
 		/*
 		 * YAML path
 		 */
-		String pathTemplate = this.applicationPath + File.separator + this.specFilename;
+		String pathTemplate = this.applicationPath + "/" + this.specFilename;
 
 		FileResourceManager resourceManager = new FileResourceManager(this.resourcePath.toFile(), 1024);
 


### PR DESCRIPTION
On Windows:
```
[...]
    GET           /v1/openapi/*                [*/*]                     [*/*]                     (OpenAPIService._)    
    GET           /v1/openapi/redoc            [*/*]                     [text/html]               (OpenAPIService._)    
    GET           /v1\openapi.yaml             [*/*]                     [text/yaml]               (OpenAPIService._) 
[...]   
```